### PR TITLE
chore: bump github checkout action

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -11,6 +11,7 @@ on:
     #       required: false
     #       default: true
     #       type: boolean
+  pull_request: {}
 
 jobs:
   push_to_registry:
@@ -18,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -35,17 +36,17 @@ jobs:
         if: "${{ steps.getversion.outputs.version != '' }}"
         run: echo ${{ steps.getversion.outputs.version }}
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        if: "${{ steps.getversion.outputs.version != '' }}"
+        uses: docker/login-action@v3
+        if: "${{ steps.getversion.outputs.version != '' && github.event_name != 'pull_request' }}"
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         if: "${{ steps.getversion.outputs.version != '' }}"
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
           build-args: |
             CZ_VERSION=${{ steps.getversion.outputs.version }}
           tags: |

--- a/scripts/auto_publish/compare-versions
+++ b/scripts/auto_publish/compare-versions
@@ -26,5 +26,5 @@ else
     echo 'Creating file: `VERSION`'
     echo "$PIP_LATEST" > VERSION
     echo "Setting variable 'version'"
-    echo "::set-output name=version::$PIP_LATEST"
+    echo "version=$PIP_LATEST" >> "$GITHUB_OUTPUT"
 fi


### PR DESCRIPTION
run on pull_requests

bump github actions

The automated push is currently broken 

```
This scheduled workflow is disabled because there hasn't been activity in this repository for at least 60 days. Enable this workflow to resume scheduled runs.
```

it would be good to enable dependabot in the repo to update the actions