### PR TITLE
chore: bump cz to 4.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN apk add --update -t --no-cache git curl alpine-sdk
 RUN ["pip", "install", "-U", "--no-cache-dir", "pip"]
 
-ARG CZ_VERSION=3.1.1
+ARG CZ_VERSION=4.1.1
 RUN pip install --no-cache-dir commitizen==$CZ_VERSION
 
 ENTRYPOINT ["cz"]


### PR DESCRIPTION
Unfortunately looks like dependabot does not support ARG versions https://github.com/dependabot/dependabot-core/issues/2057

I could submit a PR to enable renovate in the repo and allow auto updates of `CZ_VERSION`